### PR TITLE
reuse get_all_databases

### DIFF
--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -178,24 +178,32 @@ class MysqlEngine(EngineBase):
         """终止数据库连接"""
         self.query(sql=f"kill {thread_id}")
 
+    # 禁止查询的数据库
+    forbidden_databases = [
+        "information_schema",
+        "performance_schema",
+        "mysql",
+        "test",
+        "sys",
+    ]
+
     def get_all_databases(self):
         """获取数据库列表, 返回一个ResultSet"""
         sql = "show databases"
         result = self.query(sql=sql)
         db_list = [
-            row[0]
-            for row in result.rows
-            if row[0]
-            not in ("information_schema", "performance_schema", "mysql", "test", "sys")
+            row[0] for row in result.rows if row[0] not in self.forbidden_databases
         ]
         result.rows = db_list
         return result
+
+    forbidden_tables = ["test"]
 
     def get_all_tables(self, db_name, **kwargs):
         """获取table 列表, 返回一个ResultSet"""
         sql = "show tables"
         result = self.query(db_name=db_name, sql=sql)
-        tb_list = [row[0] for row in result.rows if row[0] not in ["test"]]
+        tb_list = [row[0] for row in result.rows if row[0] not in self.forbidden_tables]
         result.rows = tb_list
         return result
 

--- a/sql/engines/test_doris.py
+++ b/sql/engines/test_doris.py
@@ -1,0 +1,47 @@
+from pytest_mock import MockFixture
+
+from sql.engines.doris import DorisEngine
+from sql.engines.models import ResultSet
+
+
+def test_doris_server_info(db_instance, mocker: MockFixture):
+    mock_query = mocker.patch.object(DorisEngine, "query")
+    mock_query.return_value = ResultSet(
+        full_sql="show frontends", rows=[["foo", "bar", "2.1.0-doris"]]
+    )
+    db_instance.db_type = "doris"
+    engine = DorisEngine(instance=db_instance)
+    version = engine.server_version
+    assert version == (2, 1, 0)
+
+
+def test_doris_query(db_instance, mocker: MockFixture):
+    mock_get_connection = mocker.patch.object(DorisEngine, "get_connection")
+
+    class DummyCursor:
+        def __init__(self):
+            self.description = [("foo",), ("bar",)]
+            self.fetchall = lambda: [("baz", "qux")]
+
+        def execute(self, sql):
+            pass
+
+    mock_get_connection.return_value.cursor.return_value = DummyCursor()
+    db_instance.db_type = "doris"
+    engine = DorisEngine(instance=db_instance)
+    result_set = engine.query(sql="select * from foo")
+    assert result_set.column_list == ["foo", "bar"]
+    assert result_set.rows == [("baz", "qux")]
+    assert result_set.affected_rows == 1
+
+
+def test_forbidden_db(db_instance, mocker: MockFixture):
+    db_instance.db_type = "doris"
+    mock_query = mocker.patch.object(DorisEngine, "query")
+    mock_query.return_value = ResultSet(
+        full_sql="show databases", rows=[["__internal_schema"]]
+    )
+
+    engine = DorisEngine(instance=db_instance)
+    all_db = engine.get_all_databases()
+    assert all_db.rows == []


### PR DESCRIPTION
1. 复用 get_all_database
2. 删除 query check, mysql 中检查 是否查看 mysql 表, 并不会影响 doris 的使用, 下面新增的逻辑无必要, 因为上面已经将语句限定为 select 语句, 下方无需再做额外限制.
3. 增加 server version 和 query 的简单测试